### PR TITLE
Bug fix for upload screenshot, project image, user avatar

### DIFF
--- a/models/issue.js
+++ b/models/issue.js
@@ -2,6 +2,7 @@
 const mongoose = require('mongoose');
 const multer = require('multer');
 const path = require('path');
+const fs = require('fs')
 
 // Define the path where screenshots will be stored
 const SCREENSHOT_PATH = path.join('/uploads/issues/avatars');
@@ -53,6 +54,9 @@ const issueSchema = new mongoose.Schema({
 // Multer storage configuration for avatar uploads
 let storage = multer.diskStorage({
     destination: function (req, file, cb) {
+        if(!fs.existsSync(path.join(__dirname, '..', SCREENSHOT_PATH))){
+            fs.mkdirSync(path.join(__dirname,'..',SCREENSHOT_PATH),{recursive:true})
+        }
         // Set the destination path for storing screenshots
         cb(null, path.join(__dirname, '..', SCREENSHOT_PATH));
     },

--- a/models/project.js
+++ b/models/project.js
@@ -2,7 +2,7 @@
 const mongoose = require('mongoose');
 const multer = require('multer');
 const path = require('path');
-
+const fs = require('fs')
 // Define the path where project avatars will be stored
 const PROJECT_AVATAR_PATH = path.join('/uploads/project/avatars');
 
@@ -29,6 +29,9 @@ const projectSchema = new mongoose.Schema({
 let storage = multer.diskStorage({
     destination: function (req, file, cb) {
         // Set the destination path for storing project avatars
+        if(!fs.existsSync(path.join(__dirname, '..', PROJECT_AVATAR_PATH))){
+            fs.mkdirSync(path.join(__dirname,'..',PROJECT_AVATAR_PATH),{recursive:true})
+        }
         cb(null, path.join(__dirname, '..', PROJECT_AVATAR_PATH));
     },
     filename: function (req, file, cb) {

--- a/models/user.js
+++ b/models/user.js
@@ -2,7 +2,7 @@
 const mongoose = require('mongoose');
 const multer = require('multer');
 const path = require('path');
-
+const fs = require('fs')
 // Define the path where user avatars will be stored
 const AVATAR_PATH = path.join('/uploads/users/avatars');
 
@@ -41,6 +41,9 @@ const userSchema = new mongoose.Schema({
 let storage = multer.diskStorage({
     destination: function (req, file, cb) {
         // Set the destination path for storing user avatars
+        if(!fs.existsSync(path.join(__dirname, '..', AVATAR_PATH))){
+            fs.mkdirSync(path.join(__dirname,'..',AVATAR_PATH),{recursive:true})
+        }
         cb(null, path.join(__dirname, '..', AVATAR_PATH));
     },
     filename: function (req, file, cb) {


### PR DESCRIPTION
Bug: While uploading screenshot or project image or user avatar if the directory for the respective doesn't exists it throws **multer error as directory not found**.

Fix: Added filesystem module and checks whether the uploading path exists or not, if not using **mkdirSync** creates the respecitve directory.